### PR TITLE
feat: exclude noisy queries

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -4,3 +4,14 @@ packs:
     - opengovsg/nextjs-custom-queries
     - opengovsg/react-custom-queries
     - opengovsg/javascript-custom-queries
+query-filters:
+  - exclude:
+      id: js/hardcoded-credentials
+  - exclude:
+      id: js/client-side-unvalidated-url-redirection
+  - exclude:
+      id: js/xss
+  - exclude:
+      id: js/missing-rate-limiting
+  - exclude:
+      id: js/missing-token-validation


### PR DESCRIPTION
This excludes some noisy queries we had as part of the default query suite. Some of these are already covered by our custom, more specific queries. Hopefully this will reduce the rate of false positives and alert fatigue.

- `js/hardcoded-credentials`
    - We already have secret scanning
- `js/client-side-unvalidated-url-redirection`
    - Supercede with `nextjs/open-redirect` (also covers `javascript:` redirects from `js/xss`)
- `js/xss`
    - Supercede with `react/unsafe-dom-manipulation` or refine using their base query https://codeql.github.com/codeql-standard-libraries/javascript/semmle/javascript/security/dataflow/DomBasedXssQuery.qll/module.DomBasedXssQuery.html
- `js/missing-rate-limiting`
    - We have infra-level protections
- `js/missing-token-validation`
    - Missing CSRF middleware. But we generally don’t use `application/x-www-form-urlencoded` or `multipart/form-data` forms, and `SameSite=Lax` nowadays kills non-GET CSRFs by default

Tested on `test-codeql-alerts` repo. With the updated configuration, the old alerts opened by those rules will be [closed as fixed](https://github.com/opengovsg/test-codeql-alerts/security/code-scanning/77).