### PR TITLE
feat: add nestjs and restore open redirect queries

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -4,13 +4,10 @@ packs:
     - opengovsg/nextjs-custom-queries
     - opengovsg/react-custom-queries
     - opengovsg/javascript-custom-queries
+    - opengovsg/nestjs-custom-queries
 query-filters:
   - exclude:
       id: js/hardcoded-credentials
-  - exclude:
-      id: js/client-side-unvalidated-url-redirection
-  - exclude:
-      id: js/xss
   - exclude:
       id: js/missing-rate-limiting
   - exclude:


### PR DESCRIPTION
as title

Rationale for restoring open redirect queries:
Why should we suppress open redirect issues when it gets flagged as real issues in VAPT?
Folks who use the validators will not be flagged by the queries anyway.