### PR TITLE
feat: add ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,6 @@ jobs:
       - name: Checkout current repository
         uses: actions/checkout@v4
 
-      - name: Checkout codeql-config repository
-        uses: actions/checkout@v4
-        with:
-          repository: opengovsg/codeql-config
-          # path: codeql-config
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{(matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest'}}
     timeout-minutes: ${{(matrix.language == 'swift' && 120) || 360}}
     permissions:
+      security-events: write
       packages: read
       actions: read
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: 'CI'
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  analyze:
+    name: Analyze (${{matrix.language}})
+    runs-on: ${{(matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest'}}
+    timeout-minutes: ${{(matrix.language == 'swift' && 120) || 360}}
+    permissions:
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+
+      - name: Checkout codeql-config repository
+        uses: actions/checkout@v4
+        with:
+          repository: opengovsg/codeql-config
+          # path: codeql-config
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{matrix.language}}
+          build-mode: ${{matrix.build-mode}}
+          config-file: ./codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{matrix.language}}'
+          upload: 'never'


### PR DESCRIPTION
## Context
This repo contains a custom codeql config which is used by some repos in their workflows.
In a [previous incident](https://www.notion.so/opengov/2024-12-04-Misconfiguration-in-CodeQL-deployment-breaks-builds-for-product-teams-15277dbba78881e58d11c18ae9f1ab44), updating the codeql config resulted in failures in another project's pipeline.

## Approach
This PR adds a `ci.yml` that is similar to what other repos use in their codeql workflow.
- It checks out itself as the base repo to run codeql on.
- It then runs codeql with the updated config, so any errors in the config will cause the workflow to fail.
- This workflow will run for all PRs.

If the workflow succeeds, it means that the configuration will not break builds in the future (barring the removal of codeql packs from our container registry)

We should make sure that merging is blocked if this workflow fails.

## Testing
Will test with a nonexistent codeql pack afterwards



