### PR TITLE
feat: specify pack versions

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,10 +1,10 @@
 name: "CodeQL config"
 packs:
   javascript:
-    - opengovsg/nextjs-custom-queries
-    - opengovsg/react-custom-queries
-    - opengovsg/javascript-custom-queries
-    - opengovsg/nestjs-custom-queries
+    - opengovsg/nextjs-custom-queries@1.0.1
+    - opengovsg/react-custom-queries@1.0.1
+    - opengovsg/javascript-custom-queries@1.0.3
+    - opengovsg/nestjs-custom-queries@1.0.0
 query-filters:
   - exclude:
       id: js/hardcoded-credentials


### PR DESCRIPTION
## Context

Our CodeQL packs are published and versioned through the GitHub container registry.
The main purpose of this repo is to store the config file which teams can use to scan their repos with.
The config currently implicitly points at the latest version of each pack.
This can potentially break pipelines if a bad pack was put in the registry.

## Approach
This PR adds pack versions in the config, so that the config can be reverted to use an older version at any time.