### PR TITLE
feat: ignore test paths

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -13,7 +13,8 @@ query-filters:
   - exclude:
       id: js/missing-token-validation
 paths-ignore:
-  - '**/test*'
+  - '**/test/**'
+  - '**/tests/**'
   - '**/__test__/**'
   - '**/__tests__/**'
-  - '**/*test.*'
+  - '**/*.test.*'

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -12,3 +12,8 @@ query-filters:
       id: js/missing-rate-limiting
   - exclude:
       id: js/missing-token-validation
+paths-ignore:
+  - '**/test*'
+  - '**/__test__/**'
+  - '**/__tests__/**'
+  - '**/*test.*'


### PR DESCRIPTION
## Context

This repo contains a custom codeql config which is used by some repos in their workflows.
We note that there are many CodeQL alerts generated from test files, which are all irrelevant as the tests are not deployed in production code.

Of 300+ alerts on our repo, 30+ of them are alerts from test files, and all of them have been evaluated to be ignoreable.


## Approach

This PR adjusts the CodeQL config to remove test files from being scanned, using the `paths-ignore` directive.


## Risks

Due to the regex used, there is a possibility of interpreting non-test files as test files and therefore ignoring them.
However the reduction in false positives should readily outweigh potentially missing a finding or two.