### PR TITLE
feat: exclude missing workflow permissions

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -12,6 +12,8 @@ query-filters:
       id: js/missing-rate-limiting
   - exclude:
       id: js/missing-token-validation
+  - exclude:
+      id: actions/missing-workflow-permissions
 paths-ignore:
   - '**/test/**'
   - '**/tests/**'


### PR DESCRIPTION
## Context

This repo contains a custom codeql config which is used by some repos in their workflows.

We note that there are many CodeQL alerts generated due to 'Workflow does not contain permission'.
This rule is generally a best practice, rather than a currently exploitable vulnerability, since it requires an attacker to get an access token from a workflow created before February 2023, two prerequisites that are quite hard to achieve.

To get this access token, the attacker needs to get access to the pipeline, but by then, there are far bigger concerns e.g. leaking GH secrets.

The only other scenario is where the access token is accidentally leaked to the attacker, which is possible by supply chain attacks or somehow accidentally bundling it into the build artifact.

The probability of such a scenario seems quite slim, especially now that we enforce Github Action pinning, so it would have to be through build scripts and deps.

FYI, there are 77/613 active repos with workflows that created before February 2023.


## Approach

This PR adjusts the CodeQL config to exclude the rule `actions/missing-workflow-permissions`


## Risks
We risk the scenario where the access token is accidentally leaked to an attacker, where he will then be able to write to the repo, possibly including dumping the repo's secrets and org's secrets, or initiating a supply chain attack internally.
