### PR TITLE
chore: sync develop into prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,6 @@ jobs:
       - name: Checkout current repository
         uses: actions/checkout@v4
 
-      - name: Checkout codeql-config repository
-        uses: actions/checkout@v4
-        with:
-          repository: opengovsg/codeql-config
-          # path: codeql-config
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{(matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest'}}
     timeout-minutes: ${{(matrix.language == 'swift' && 120) || 360}}
     permissions:
+      security-events: write
       packages: read
       actions: read
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: 'CI'
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  analyze:
+    name: Analyze (${{matrix.language}})
+    runs-on: ${{(matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest'}}
+    timeout-minutes: ${{(matrix.language == 'swift' && 120) || 360}}
+    permissions:
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+
+      - name: Checkout codeql-config repository
+        uses: actions/checkout@v4
+        with:
+          repository: opengovsg/codeql-config
+          # path: codeql-config
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{matrix.language}}
+          build-mode: ${{matrix.build-mode}}
+          config-file: ./codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{matrix.language}}'
+          upload: 'never'

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -12,3 +12,9 @@ query-filters:
       id: js/missing-rate-limiting
   - exclude:
       id: js/missing-token-validation
+paths-ignore:
+  - '**/test/**'
+  - '**/tests/**'
+  - '**/__test__/**'
+  - '**/__tests__/**'
+  - '**/*.test.*'

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,10 +1,10 @@
 name: "CodeQL config"
 packs:
   javascript:
-    - opengovsg/nextjs-custom-queries
-    - opengovsg/react-custom-queries
-    - opengovsg/javascript-custom-queries
-    - opengovsg/nestjs-custom-queries
+    - opengovsg/nextjs-custom-queries@1.0.1
+    - opengovsg/react-custom-queries@1.0.1
+    - opengovsg/javascript-custom-queries@1.0.3
+    - opengovsg/nestjs-custom-queries@1.0.0
 query-filters:
   - exclude:
       id: js/hardcoded-credentials

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -4,13 +4,10 @@ packs:
     - opengovsg/nextjs-custom-queries
     - opengovsg/react-custom-queries
     - opengovsg/javascript-custom-queries
+    - opengovsg/nestjs-custom-queries
 query-filters:
   - exclude:
       id: js/hardcoded-credentials
-  - exclude:
-      id: js/client-side-unvalidated-url-redirection
-  - exclude:
-      id: js/xss
   - exclude:
       id: js/missing-rate-limiting
   - exclude:

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -12,6 +12,8 @@ query-filters:
       id: js/missing-rate-limiting
   - exclude:
       id: js/missing-token-validation
+  - exclude:
+      id: actions/missing-workflow-permissions
 paths-ignore:
   - '**/test/**'
   - '**/tests/**'

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,4 @@
+// Placeholder file to allow CodeQL's javascript-typescript analysis to run.
+// This repo is a config-only repo with no application code, but the CI
+// workflow needs at least one JS/TS file for the analyzer to succeed.
+export {};

--- a/sample-workflow.yml
+++ b/sample-workflow.yml
@@ -1,0 +1,77 @@
+# OGP CodeQL Workflow
+# Copy this file to your repository at .github/workflows/codeql.yml
+#
+# To exclude specific rules for your project, create .github/codeql-config.yml
+# in your repository with contents like:
+#
+#   packs:
+#     javascript:
+#       - opengovsg/nextjs-custom-queries@1.0.1
+#       - opengovsg/react-custom-queries@1.0.1
+#       - opengovsg/javascript-custom-queries@1.0.3
+#       - opengovsg/nestjs-custom-queries@1.0.0
+#   query-filters:
+#     - exclude:
+#         id: my-rule/to-exclude
+#   paths-ignore:
+#     - '**/test/**'
+#     - '**/tests/**'
+#     - '**/__test__/**'
+#     - '**/__tests__/**'
+#     - '**/*.test.*'
+#
+# If no local config is found, the central config from
+# opengovsg/codeql-config/codeql-config.yml@prod is used.
+
+name: 'OGP CodeQL'
+
+on:
+  push:
+    branches: ['develop']
+  pull_request:
+    branches: ['develop']
+  schedule:
+    - cron: '0 10 * * *'
+
+jobs:
+  analyze:
+    name: Analyze (${{matrix.language}})
+    runs-on: ${{(matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest'}}
+    timeout-minutes: ${{(matrix.language == 'swift' && 120) || 360}}
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for local CodeQL config override
+        id: codeql-config
+        run: |
+          if [ -f ".github/codeql-config.yml" ]; then
+            echo "config-file=./.github/codeql-config.yml" >> "$GITHUB_OUTPUT"
+          else
+            echo "config-file=opengovsg/codeql-config/codeql-config.yml@prod" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{matrix.language}}
+          build-mode: ${{matrix.build-mode}}
+          config-file: ${{steps.codeql-config.outputs.config-file}}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## Summary
- Syncs all changes from `develop` into `prod` (10 commits behind)
- `prod` is the branch referenced by org-wide CodeQL workflows, so this applies all pending config changes across the organization

## Changes included
- feat: add nestjs and restore open redirect queries
- feat: add ci checks
- fix: removed duplicate checkout action
- fix: add security events write to reduce configuration drift
- feat: specify pack versions
- feat: ignore test paths
- feat: exclude missing workflow permissions