### PR TITLE
feat: add actions and supply-chain packs

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,7 +1,7 @@
 name: "CodeQL config"
 packs:
   actions:
-    - opengovsg/actions-custom-queries@1.0.1
+    - opengovsg/actions-custom-queries@1.0.2
   javascript:
     - opengovsg/nextjs-custom-queries@1.0.1
     - opengovsg/react-custom-queries@1.0.1

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,10 +1,13 @@
 name: "CodeQL config"
 packs:
+  actions:
+    - opengovsg/actions-custom-queries@1.0.0
   javascript:
     - opengovsg/nextjs-custom-queries@1.0.1
     - opengovsg/react-custom-queries@1.0.1
     - opengovsg/javascript-custom-queries@1.0.3
     - opengovsg/nestjs-custom-queries@1.0.0
+    - opengovsg/supply-chain-release-age-queries@1.0.0
 query-filters:
   - exclude:
       id: js/hardcoded-credentials

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,7 +1,7 @@
 name: "CodeQL config"
 packs:
   actions:
-    - opengovsg/actions-custom-queries@1.0.2
+    - opengovsg/actions-custom-queries@1.1.0
   javascript:
     - opengovsg/nextjs-custom-queries@1.0.1
     - opengovsg/react-custom-queries@1.0.1

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,7 +1,7 @@
 name: "CodeQL config"
 packs:
   actions:
-    - opengovsg/actions-custom-queries@1.1.0
+    - opengovsg/actions-custom-queries@1.1.1
   javascript:
     - opengovsg/nextjs-custom-queries@1.0.1
     - opengovsg/react-custom-queries@1.0.1

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,7 +1,7 @@
 name: "CodeQL config"
 packs:
   actions:
-    - opengovsg/actions-custom-queries@1.0.0
+    - opengovsg/actions-custom-queries@1.0.1
   javascript:
     - opengovsg/nextjs-custom-queries@1.0.1
     - opengovsg/react-custom-queries@1.0.1


### PR DESCRIPTION
## Summary

- Adds `opengovsg/actions-custom-queries@1.0.0` under a new `actions:` packs section for scanning GitHub Actions workflows (e.g. unfrozen package installs)
- Adds `opengovsg/supply-chain-release-age-queries@1.0.0` under the existing `javascript:` packs section for dependabot cooldown and pnpm workspace minimum release age checks

## Notes

- The `actions` pack only runs on repos that include `actions` in their CodeQL language matrix
- The `supply-chain-release-age-queries` pack uses the JavaScript extractor, so it will run on all JS/TS repos automatically

## Test plan

- [x] Verify CodeQL analysis runs successfully on a repo with `actions` in its language matrix and picks up the new actions queries
- [x] Verify CodeQL analysis on a JS repo picks up the supply-chain-release-age-queries
- [x] Confirm existing JavaScript/NestJS/Next.js/React queries continue to work as before